### PR TITLE
pxgsettings: g_signal_connect does not emmit changed signals

### DIFF
--- a/libproxy/modules/pxgsettings.cpp
+++ b/libproxy/modules/pxgsettings.cpp
@@ -149,10 +149,9 @@ int main(int argc, char **argv) {
 	for (int i=1; i<argc; i++) {
 		settings = g_settings_new(argv[i]);
 		gchar** keys = g_settings_list_keys(settings);
+		g_signal_connect(settings, "changed::", G_CALLBACK (on_value_change), argv[i]);
 		for (int j=0; keys[j]; on_value_change(settings, keys[j++],argv[i] ));
-		g_signal_connect(settings, "changed::", (GCallback) on_value_change, argv[i]);
 	}
-
 
 	g_main_loop_run(loop);
 


### PR DESCRIPTION
ion recent versions of GLIB, it is mandatory to FIRST connect to the changed:: signal and then read values.
Without reading the values, it seems there is an initialization missing to start the change monitoring.

So: we now first connect the signal handler, directly followed by reading all the settings we care about.