### PR TITLE
Make the KDE config module optional again.

### DIFF
--- a/libproxy/cmake/modules/config_kde.cmk
+++ b/libproxy/cmake/modules/config_kde.cmk
@@ -1,6 +1,10 @@
-find_program(KDE4_CONF kreadconfig)
-find_program(KF5_CONF kreadconfig5)
+option(WITH_KDE "Build module to read proxy settings from KDE4/KF5" ON)
 
-if (KDE4_CONF OR KF5_CONF)
-  set(KDE_FOUND 1)
+if (WITH_KDE)
+  find_program(KDE4_CONF kreadconfig)
+  find_program(KF5_CONF kreadconfig5)
+
+  if (KDE4_CONF OR KF5_CONF)
+    set(KDE_FOUND 1)
+  endif()
 endif()


### PR DESCRIPTION
This is a follow-up to bd9bf72 ("Add generic KDE config module"): make
it possible for distributions to not build the KDE config module at all,
even if it does not have any dependencies on Qt/KDE/KF5.