### PR TITLE
Revert "bindings: perl: Do not link against libperl."

### DIFF
--- a/bindings/perl/src/CMakeLists.txt
+++ b/bindings/perl/src/CMakeLists.txt
@@ -12,7 +12,7 @@ set(Libproxy_LIB_SRCS Libproxy.c)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/perl/blib/arch/auto/Net)
 add_library(PLlibproxy SHARED ${Libproxy_LIB_SRCS})
 
-target_link_libraries(PLlibproxy libproxy pthread)
+target_link_libraries(PLlibproxy ${PERL_LIBRARY} libproxy pthread)
 set_target_properties(PLlibproxy PROPERTIES OUTPUT_NAME "Libproxy")
 set_target_properties(PLlibproxy PROPERTIES PREFIX "")
 


### PR DESCRIPTION
This reverts commit 5077b7563369a89d906fa32c040bb953c3b628bb.

The original change breaks linking with `-Wl,--no-undefined`, which is the
default on distros such as Fedora and Debian, and it also makes some
sanity tests on FreeBSD to fail since the code uses Perl symbols but
does not link against libperl.so. There does not seem to be a big
benefit in building the binding with a Perl version other than the
installed on, especially since most distros simply rebuild everything
when switching Perl versions.