### PR TITLE
travis-ci: add config file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+langauge: cpp
+compiler:
+  - gcc
+  - clang
+script:
+  - cmake .
+  - make
+  - sudo make install
+  - make test


### PR DESCRIPTION
Let's get some minimal travis tests in here

Things left to do:
  * Decide which plugins we all want to test on Travis, install the build deps and enable the modules

Other than that, once I enable travis for /libproxy/libproxy, we at least get the PullReqs all tested as well.

Current test run: https://travis-ci.org/DimStar77/libproxy/builds/103157130