### PR TITLE
bindings: perl: Add an option to explicitly link against libperl.so.

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -84,6 +84,11 @@ PERL_VENDORINSTALL:     Default to OFF. Tells cmake to install the perl binding
                         in the vendor directory, which is the one used by most
                         packagers.
 
+PERL_LINK_LIBPERL:      Default to ON if PERL_VENDORINSTALL is OFF, default to
+                        OFF otherwise. Explicitly links the Perl binding
+                        against libperl.so. It must be ON for linking to work
+                        when --no-undefined is passed to the linker.
+
 WITH_DOTNET:            Default to OFF. Enable Mono .NET bindings.
 
 WITH_GNOME:             Default to ON. Enable Gnome2/GConf bindings.

--- a/bindings/perl/CMakeLists.txt
+++ b/bindings/perl/CMakeLists.txt
@@ -10,6 +10,19 @@ if(PERL_FOUND AND PERLLIBS_FOUND)
     # Some distributions install perl packages in vendor when shipped with the distro.
     # Let's make their lifes easier by offering an install flag for this usecase.
     option(PERL_VENDORINSTALL "Install Perl package in vendor directory" OFF)
+
+    # Offer an option to explicitly link against libperl.so, with a default
+    # that depends on the value of the PERL_VENDORINSTALL option: if the
+    # binding is installed into a version-independent directory such as
+    # vendor_perl the chances of it needing a rebuild on each Perl update are
+    # lower. Note: not linking against libperl.so does not work if
+    # --no-undefined is passed to the linker.
+    if(PERL_VENDORINSTALL)
+        option(PERL_LINK_LIBPERL "Explicitly link against libperl.so" OFF)
+    else()
+        option(PERL_LINK_LIBPERL "Explicitly link against libperl.so" ON)
+    endif()
+
     if(PERL_VENDORINSTALL)
       set (PX_PERL_ARCH ${PERL_VENDORARCH})
       set (PX_PERL_LIB ${PERL_VENDORLIB})

--- a/bindings/perl/src/CMakeLists.txt
+++ b/bindings/perl/src/CMakeLists.txt
@@ -12,7 +12,12 @@ set(Libproxy_LIB_SRCS Libproxy.c)
 set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/perl/blib/arch/auto/Net)
 add_library(PLlibproxy SHARED ${Libproxy_LIB_SRCS})
 
-target_link_libraries(PLlibproxy libproxy pthread)
+set(PLlibproxy_LIB_DEPENDENCIES libproxy pthread)
+if(PERL_LINK_LIBPERL)
+  set(PLlibproxy_LIB_DEPENDENCIES ${PERL_LIBRARY} ${PLlibproxy_LIB_DEPENDENCIES})
+endif()
+
+target_link_libraries(PLlibproxy ${PLlibproxy_LIB_DEPENDENCIES})
 set_target_properties(PLlibproxy PROPERTIES OUTPUT_NAME "Libproxy")
 set_target_properties(PLlibproxy PROPERTIES PREFIX "")
 


### PR DESCRIPTION
The Perl binding uses symbols from libperl.so, but since it is always
run after libperl.so itself is loaded, not linking against it does not
cause the problems that would normally occur.

Doing so was mandatory since 5077b75 ("bindings: perl: Do not link
against libperl"), which was catering for distros which install the
binding into vendor_perl and try not to rebuild all their Perl packages
on every Perl update. The flip-side is that it breaks things for other
groups: distros that install the binding into a versioned Perl
directory and allow different Perl versions to be installed
concurrently (for example, FreeBSD), or distros that pass
"--no-undefined" to the linker.

Provide an option, PERL_LINK_LIBPERL (whose default depends on the value
of PERL_VENDORINSTALL), to make the behavior configurable.