### PR TITLE
python: Avoid a crash on 64-bit systems

### DIFF
--- a/bindings/python/libproxy.py
+++ b/bindings/python/libproxy.py
@@ -40,8 +40,12 @@ if platform.system() == "Windows":
 else:
     _libc = _load("c", 6)
 
+_libc.free.argtypes = ctypes.c_void_p,
+
 # Load libproxy
 _libproxy = _load("proxy", 1)
+_libproxy.px_proxy_factory_new.restype = ctypes.POINTER(ctypes.c_void_p)
+_libproxy.px_proxy_factory_free.argtypes = ctypes.c_void_p,
 _libproxy.px_proxy_factory_get_proxies.restype = ctypes.POINTER(ctypes.c_void_p)
 
 class ProxyFactory(object):


### PR DESCRIPTION
Annotate the return type of px_proxy_factory_new() to be void *, as otherwise
int is assumed. This works fine on 32-bit systems, where void * and int are the
same width, but is invalid on 64-bit (Linux) systems.

Additionally, annotate the argument type of free() and px_proxy_factory_free()
to be void * to match.

https://code.google.com/archive/p/libproxy/issues/146