### PR TITLE
Fix #24 NULL pointer dereference in ignore_ip.cpp line 151

### DIFF
--- a/libproxy/modules/ignore_ip.cpp
+++ b/libproxy/modules/ignore_ip.cpp
@@ -147,7 +147,7 @@ public:
 			else
 			{
 				/* If CIDR notation was used, get the netmask */
-				if (sscanf(mask.c_str(), "%d", &cidr) == 1)
+				if (ign_ip && sscanf(mask.c_str(), "%d", &cidr) == 1)
 					net_ip = sockaddr_from_cidr(ign_ip->sa_family, cidr);
 			}
 


### PR DESCRIPTION
Qt5 started to use libproxy and this exposed a crashing bug on OpenBSD
when using Qt5 applications on Gnome 3.

Here's a sample backtrace:
 https://gist.github.com/mulander/c03997ae7e3fe4e30af0d4f2ce2965f0

The issue is caused by an unguarded dereference of ign_ip.

Other parts of the code properly expect that sockaddr_from_string
might return null and guard against it.

Adding a proper guard prevents a segfault both in OpenBSD
www/otter-browser and devel/zeal.