### PR TITLE
GNOME3: Wait for pxgsettings to vanish while destroying the plugin

### DIFF
--- a/libproxy/modules/config_gnome3.cpp
+++ b/libproxy/modules/config_gnome3.cpp
@@ -24,6 +24,7 @@
 #include <sys/types.h>    // For stat()
 #include <sys/stat.h>     // For stat()
 #include <unistd.h>       // For pipe(), close(), vfork(), dup(), execl(), _exit()
+#include <sys/wait.h>     // For waitpid()
 #include <signal.h>       // For kill()
 
 #include "../extension_config.hpp"
@@ -161,6 +162,7 @@ public:
 		fclose(this->read);
 		fclose(this->write);
 		kill(this->pid, SIGTERM);
+		waitpid(this->pid, NULL, 0);
 	}
 
 	void store_response(const string &type,


### PR DESCRIPTION
This helps avoiding zombie processes in case a caller creates/destroys
ProxyFactories for each URL (even though we recommend to have a long-living
PF for caching reasons).

Originally reported at https://bugzilla.opensuse.org/show_bug.cgi?id=967601