### PR TITLE
FindMono: fall back to mcs when gmcs cannot be found

### DIFF
--- a/cmake/FindMono.cmake
+++ b/cmake/FindMono.cmake
@@ -12,7 +12,7 @@
 # Redistribution and use is allowed according to the terms of the GPL license.
 
 FIND_PROGRAM (MONO_EXECUTABLE mono)
-FIND_PROGRAM (GMCS_EXECUTABLE gmcs)
+FIND_PROGRAM (GMCS_EXECUTABLE NAMES gmcs mcs)
 FIND_PROGRAM (GACUTIL_EXECUTABLE gacutil)
 
 SET (MONO_FOUND FALSE CACHE INTERNAL "")


### PR DESCRIPTION
With mono 4.6, gmcs is no longer an upstream shipped wrapper.
Just fallback to 'mcs' if gmcs cannot be found. Distros still shipping
gmcs are assumed to know why they do so - in this case we favor their
local scripts.

Fixes issue #37.