### PR TITLE
Set CMP0054 CMake policy to NEW.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,9 @@ cmake_minimum_required(VERSION 2.6)
 if(POLICY CMP0011)
    cmake_policy(SET CMP0011 NEW)
 endif(POLICY CMP0011)
+if(POLICY CMP0054)
+   cmake_policy(SET CMP0054 NEW)
+endif(POLICY CMP0054)
 
 # Make sure we look in our cmake folder for additional definitions
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake )


### PR DESCRIPTION
CMake 3.7 exports a "t" variable for all projects and because of that
the elseif statement in cmake/CMakeCSharpInformation.cmake:311 works
incorrectly if CMP0054 is not set to NEW (as "t" is expanded to the
variable value).