### PR TITLE
Use StateChanged signal instead of StateChange

### DIFF
--- a/libproxy/modules/network_networkmanager.cpp
+++ b/libproxy/modules/network_networkmanager.cpp
@@ -62,7 +62,7 @@ public:
 
 			// If connection was successful, set it up
 			dbus_connection_set_exit_on_disconnect(conn, false);
-			dbus_bus_add_match(conn, "type='signal',interface='" NM_DBUS_INTERFACE "',member='StateChange'", NULL);
+			dbus_bus_add_match(conn, "type='signal',interface='" NM_DBUS_INTERFACE "',member='StateChanged'", NULL);
 			dbus_connection_flush(conn);
 		}
 


### PR DESCRIPTION
StateChange signal has been deprecated since NM 0.7 and has been
completely removed in 0.9, see:
https://developer.gnome.org/NetworkManager/0.9/ref-migrating.html

Closes: #58