### PR TITLE
Set lasturl to NULL after free/delete

### DIFF
--- a/libproxy/modules/wpad_dns_alias.cpp
+++ b/libproxy/modules/wpad_dns_alias.cpp
@@ -39,6 +39,7 @@ public:
 		lastpac = *pac = lasturl->get_pac();
 		if (!lastpac) {
 		    delete lasturl;
+		    lasturl = NULL;
 		    return NULL;
 		}
 


### PR DESCRIPTION
It avoids the lasturl to be freed a 2nd time when the rewind() method is
called.

Closes: #59