### PR TITLE
Add public px_proxy_factory_free_proxies function

### DIFF
--- a/bindings/csharp/libproxy.cs
+++ b/bindings/csharp/libproxy.cs
@@ -33,6 +33,10 @@ namespace libproxy {
 			IntPtr px_proxy_factory_get_proxies(HandleRef self, string url);
 		
 		[DllImport ("proxy")]
+		private static extern 
+			void px_proxy_factory_free_proxies(IntPtr proxies);
+		
+		[DllImport ("proxy")]
 		private static extern
 			void px_proxy_factory_free(HandleRef self);
 
@@ -61,11 +65,9 @@ namespace libproxy {
 			{
 				IntPtr p = Marshal.ReadIntPtr(array, i * IntPtr.Size);
 				proxies[i] = Marshal.PtrToStringAnsi(p);
-				Marshal.FreeCoTaskMem(p); // Free the string
 			}
-			
-			// Free the array itself
-			Marshal.FreeCoTaskMem(array);
+
+			px_proxy_factory_free_proxies(array);
 			
 			return proxies;
 		}

--- a/bindings/perl/src/Libproxy.xs
+++ b/bindings/perl/src/Libproxy.xs
@@ -49,6 +49,11 @@ proxy_factory_get_proxies(pf, url)
   OUTPUT:
     RETVAL
 
+void
+proxy_factory_free_proxies(proxies)
+    char ** proxies
+  CODE:
+    px_proxy_factory_free_proxies(proxies);
 
 MODULE = Net::Libproxy PACKAGE = Net::Libproxy::ProxyFactoryPtr
 

--- a/bindings/python/libproxy.py
+++ b/bindings/python/libproxy.py
@@ -40,13 +40,12 @@ if platform.system() == "Windows":
 else:
     _libc = _load("c", 6)
 
-_libc.free.argtypes = ctypes.c_void_p,
-
 # Load libproxy
 _libproxy = _load("proxy", 1)
 _libproxy.px_proxy_factory_new.restype = ctypes.POINTER(ctypes.c_void_p)
 _libproxy.px_proxy_factory_free.argtypes = ctypes.c_void_p,
 _libproxy.px_proxy_factory_get_proxies.restype = ctypes.POINTER(ctypes.c_void_p)
+_libproxy.px_proxy_factory_free_proxies.argtypes = ctypes.POINTER(ctypes.c_void_p)
 
 class ProxyFactory(object):
     """A ProxyFactory object is used to provide potential proxies to use
@@ -120,9 +119,9 @@ class ProxyFactory(object):
         i=0
         while array[i]:
             proxies.append(str(ctypes.cast(array[i], ctypes.c_char_p).value))
-            _libc.free(array[i])
             i += 1
-        _libc.free(array)
+
+        _libproxy.px_proxy_factory_free_proxies(proxies)
         
         return proxies
         

--- a/libproxy/libproxy.map
+++ b/libproxy/libproxy.map
@@ -1,4 +1,4 @@
-LIBPROXY {
+LIBPROXY_0.4.16 {
   global:
     px_proxy_factory_new;
     px_proxy_factory_get_proxies;

--- a/libproxy/libproxy.map
+++ b/libproxy/libproxy.map
@@ -2,8 +2,8 @@ LIBPROXY {
   global:
     px_proxy_factory_new;
     px_proxy_factory_get_proxies;
+    px_proxy_factory_free_proxies;
     px_proxy_factory_free;
   local: *;
 };
-
 

--- a/libproxy/proxy.cpp
+++ b/libproxy/proxy.cpp
@@ -483,6 +483,16 @@ extern "C" DLL_PUBLIC char** px_proxy_factory_get_proxies(struct pxProxyFactory_
 	return retval;
 }
 
+extern "C" DLL_PUBLIC void px_proxy_factory_free_proxies(char ** const proxies) {
+	if (!proxies)
+		return;
+
+	for (size_t i = 0; proxies[i]; ++i)
+		free(proxies[i]);
+
+	free(proxies);
+}
+
 extern "C" DLL_PUBLIC void px_proxy_factory_free(struct pxProxyFactory_ *self) {
 	delete self;
 }

--- a/libproxy/proxy.h
+++ b/libproxy/proxy.h
@@ -84,11 +84,20 @@ pxProxyFactory *px_proxy_factory_new(void);
  * previous does not exist. As an example, on Mac OS X you can configure a
  * RTSP streaming proxy. The expected returned configuration would be:
  *   - rtsp://[username:password@]proxy:port
+ *
+ * To free the returned value, call px_proxy_factory_free_proxies.
  * 
  * @url The URL we are trying to reach
  * @return A NULL-terminated array of proxy strings to use
  */
 char **px_proxy_factory_get_proxies(pxProxyFactory *self, const char *url);
+
+/**
+ * Frees the proxy array returned by px_proxy_factory_get_proxies when no
+ * longer used.
+ * @since 0.4.16
+ */
+void px_proxy_factory_free_proxies(char **proxies);
 
 /**
  * Frees the pxProxyFactory instance when no longer used.

--- a/samples/libcurl/curlget.c
+++ b/samples/libcurl/curlget.c
@@ -86,9 +86,6 @@ int main(int argc, char * argv[]) {
       result = curl_easy_perform(curl);
     }
 
-    /* Free the proxy */
-    free(proxies[i]);
-
     /* If we reached the end of the proxies array and still did not
     succeed to conntect, let's inform the user that we failed. */
     if (proxies[i+1] == NULL && result != 0)
@@ -96,8 +93,8 @@ int main(int argc, char * argv[]) {
 
   }
 
-  /* Free the (now empty) proxy array */
-  free(proxies);
+  /* Free the proxy array */
+  px_proxy_factory_free_proxies(proxies);
 
   /* Free the curl and libproxy handles */
   px_proxy_factory_free(pf);

--- a/utils/proxy.c
+++ b/utils/proxy.c
@@ -50,11 +50,7 @@ print_proxies(char **proxies)
 	}
 
 	for (j=0; proxies[j] ; j++)
-	{
 		printf("%s%s", proxies[j], proxies[j+1] ? " " : "\n");
-		free(proxies[j]);
-	}
-	free(proxies);
 }
 
 int
@@ -62,6 +58,7 @@ main(int argc, char **argv)
 {
 	int i;
 	char url[102400]; // Should be plently long for most URLs
+	char **proxies;
 
 	/* Create the proxy factory object */
 	pxProxyFactory *pf = px_proxy_factory_new();
@@ -80,7 +77,9 @@ main(int argc, char **argv)
 			 * in the order returned. Only move on to the next proxy
 			 * if the first one fails (etc).
 			 */
-			print_proxies(px_proxy_factory_get_proxies(pf, argv[i]));
+			proxies = px_proxy_factory_get_proxies(pf, argv[i]);
+			print_proxies(proxies);
+			px_proxy_factory_free_proxies(proxies);
 		}
 	}
 	/* Interactive mode */
@@ -96,7 +95,9 @@ main(int argc, char **argv)
 			 * in the order returned. Only move on to the next proxy
 			 * if the first one fails (etc).
 			 */
-			print_proxies(px_proxy_factory_get_proxies(pf, url));
+			proxies = px_proxy_factory_get_proxies(pf, url);
+			print_proxies(proxies);
+			px_proxy_factory_free_proxies(proxies);
 		}
 	}
 	/* Destroy the proxy factory object */


### PR DESCRIPTION
Fixes issue #43.

Testcases still pass, but apparently they don't even use ```px_proxy_factory_get_proxies```...
```utils/proxy``` still works. I did not test any of the bindings and I'm also pretty sure that they're currently broken. I don't know how to fixup the bindings though, I never worked with any of those, especially vala.