### PR TITLE
Add symbol versions - be ready to introduce new APIs as needed

### DIFF
--- a/libproxy/cmake/libproxy.cmk
+++ b/libproxy/cmake/libproxy.cmk
@@ -21,5 +21,8 @@ set_property(SOURCE ${CMAKE_CURRENT_SOURCE_DIR}/proxy.cpp
 set_target_properties(libproxy PROPERTIES PREFIX "" VERSION 1.0.0 SOVERSION 1)
 set_target_properties(libproxy PROPERTIES INTERFACE_LINK_LIBRARIES "")
 set_target_properties(libproxy PROPERTIES LINK_INTERFACE_LIBRARIES "")
+if(NOT APPLE)
+  set_target_properties(libproxy PROPERTIES LINK_FLAGS "-Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/libproxy.map")
+endif()
 install(TARGETS libproxy DESTINATION ${LIB_INSTALL_DIR})
 install(FILES   proxy.h  DESTINATION ${INCLUDE_INSTALL_DIR})

--- a/libproxy/libproxy.map
+++ b/libproxy/libproxy.map
@@ -1,0 +1,9 @@
+LIBPROXY {
+  global:
+    px_proxy_factory_new;
+    px_proxy_factory_get_proxies;
+    px_proxy_factory_free;
+  local: *;
+};
+
+


### PR DESCRIPTION
Preparation for https://github.com/libproxy/libproxy/pull/70, so that we can version new API being added

Any binary built against libproxy.so.1 before this was added, will keep on working (as long as we do only EXTEND the ABI, and not CHANGE)

Binaries built against the newer version of libproxy.so.1 will get additional information about the exported symbol name (i.e. LIBPROXY for the 'initial set', LIBPROXY_x_y_z for upcoming future APIs) - and will thus have proper dependencies too