### PR TITLE
python: support Python 3.7 and 3.8

### DIFF
--- a/cmake/FindPython3Interp.cmake
+++ b/cmake/FindPython3Interp.cmake
@@ -39,7 +39,7 @@
 
 unset(_Python3_NAMES)
 
-set(_Python3_VERSIONS 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
+set(_Python3_VERSIONS 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
 
 if(Python3Interp_FIND_VERSION)
     if(Python3Interp_FIND_VERSION_COUNT GREATER 1)


### PR DESCRIPTION
Add 3.7 and 3.8 to the list of accepted Python 3 versions.