### PR TITLE
Add call to JS::InitSelfHostedCode()

### DIFF
--- a/libproxy/modules/pacrunner_mozjs.cpp
+++ b/libproxy/modules/pacrunner_mozjs.cpp
@@ -118,6 +118,8 @@ public:
 		// Initialize Javascript context
 		if (!(this->jsctx = JS_NewContext(1024 * 1024)))     goto error;
 		{
+			if (!JS::InitSelfHostedCode(this->jsctx)) goto error;
+
 			JS::RootedValue  rval(this->jsctx);
 			JS::CompartmentOptions compart_opts;
 


### PR DESCRIPTION
This is needed otherwise mozjs crashes