### PR TITLE
Revert "Do not invoke extra shell to run pxgsettings"

### DIFF
--- a/libproxy/modules/config_gnome3.cpp
+++ b/libproxy/modules/config_gnome3.cpp
@@ -97,7 +97,7 @@ static int popen2(const char *program, FILE** read, FILE** write, pid_t* pid) {
 			close(i);
 
 		// Exec
-		execl(program, (char*) NULL);
+		execl("/bin/sh", "sh", "-c", program, (char*) NULL);
 		_exit(127);  // Whatever we do, don't return
 
 	default: // Parent


### PR DESCRIPTION

> sigh
> 
> OK I now see why it was using /bin/sh to start the helper.
> 
> It's because the code is concatenate the gsettings keys to watch (in all_keys) as parameters
> 
> So this is not enough to just remove /bin/bash
> 

This reverts commit 8012bed4405efa31fffb57d6282de3e1513e4bd9.