### PR TITLE
include <string.h> in modules/config_gnome3.cpp

### DIFF
--- a/libproxy/modules/config_gnome3.cpp
+++ b/libproxy/modules/config_gnome3.cpp
@@ -26,6 +26,7 @@
 #include <unistd.h>       // For pipe(), close(), vfork(), dup(), execl(), _exit()
 #include <sys/wait.h>     // For waitpid()
 #include <signal.h>       // For kill()
+#include <string.h>       // For memset() [used in FD_ZERO() on Solaris]
 
 #include "../extension_config.hpp"
 using namespace libproxy;


### PR DESCRIPTION
Needed to fix build on Solaris 11:

libproxy/modules/config_gnome3.cpp:190:3: error: ‘memset’ was not declared
 in this scope
   FD_ZERO(&rfds);
   ^

Signed-off-by: Alan Coopersmith <alan.coopersmith@oracle.com>