### PR TITLE
get-pac-test: Fix build with clang/libc++

### DIFF
--- a/libproxy/test/get-pac-test.cpp
+++ b/libproxy/test/get-pac-test.cpp
@@ -52,7 +52,7 @@ class TestServer {
 
 			setsockopt(m_sock, SOL_SOCKET, SO_REUSEADDR, &i, sizeof(i));
 
-			ret = bind(m_sock, (sockaddr*)&addr, sizeof (struct sockaddr_in));
+			ret = ::bind(m_sock, (sockaddr*)&addr, sizeof (struct sockaddr_in));
 			assert(!ret);
 
 			ret = listen(m_sock, 1);


### PR DESCRIPTION
get-pac-test.cpp:55:10: error: assigning to 'int' from incompatible type '__bind<int &, sockaddr *, unsigned int>'
                        ret = bind(m_sock, (sockaddr*)&addr, sizeof (struct sockaddr_in));                              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Khem Raj <raj.khem@gmail.com>