### PR TITLE
New attempt to merge pacrunner support

### DIFF
--- a/libproxy/cmake/modules.cmk
+++ b/libproxy/cmake/modules.cmk
@@ -8,6 +8,7 @@ endif()
 # Do module determination
 include(cmake/pxmodule.cmk)
 include(cmake/pkgconfig.cmk)
+include(cmake/modules/config_pacrunner.cmk)
 include(cmake/modules/config_envvar.cmk)
 include(cmake/modules/config_sysconfig.cmk)
 include(cmake/modules/config_gnome.cmk)
@@ -28,6 +29,7 @@ endif()
 ## Module definition
 #
 message("MODULES TO BUILD:")
+px_module(config_pacrunner         "${DBUS_FOUND}"   0       ${DBUS_LIBRARIES})
 px_module(config_envvar            "${ENVVAR_FOUND}" 1)
 px_module(config_sysconfig         "${SYSCONFIG_FOUND}" 1)
 px_module(config_gnome             "${GNOME2_FOUND}" 0)

--- a/libproxy/cmake/modules/config_pacrunner.cmk
+++ b/libproxy/cmake/modules/config_pacrunner.cmk
@@ -1,0 +1,3 @@
+if (NOT WIN32 AND NOT APPLE)
+  px_check_modules(DBUS dbus-1)
+endif()

--- a/libproxy/modules/config_pacrunner.cpp
+++ b/libproxy/modules/config_pacrunner.cpp
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * libproxy - A library for proxy configuration
+ * Copyright (C) 2010 Intel Corporation
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
+ ******************************************************************************/
+
+#include "../extension_config.hpp"
+using namespace libproxy;
+
+#include <string.h>
+#include <dbus/dbus.h>
+
+class pacrunner_config_extension : public config_extension {
+public:
+	pacrunner_config_extension() {
+		this->conn = NULL;
+	}
+
+	~pacrunner_config_extension() {
+		if (this->conn) dbus_connection_close(this->conn);
+	}
+
+	class scoped_dbus_message {
+	public:
+		scoped_dbus_message(DBusMessage *msg) {
+			this->msg = msg;
+		}
+
+		~scoped_dbus_message() {
+			if (this->msg)
+				dbus_message_unref(msg);
+		}
+
+	private:
+		DBusMessage *msg;
+	};
+
+	vector<url> get_config(const url &dest) throw (runtime_error) {
+		// Make sure we have a valid connection with a proper match
+		DBusConnection *conn = this->conn;
+		vector<url> response;
+
+		if (!conn || !dbus_connection_get_is_connected(conn))
+		{
+			// If the connection was disconnected,
+			// close it an clear the queue
+			if (conn)
+			{
+				dbus_connection_close(conn);
+				dbus_connection_read_write(conn, 0);
+				for (DBusMessage *msg=NULL ; (msg = dbus_connection_pop_message(conn)) ; dbus_message_unref(msg)) {};
+			}
+
+			// Create a new connections
+			conn = dbus_bus_get_private(DBUS_BUS_SYSTEM, NULL);
+			this->conn = conn;
+			if (!conn)
+				throw runtime_error("Unable to set up DBus connection");
+
+			// If connection was successful, set it up
+			dbus_connection_set_exit_on_disconnect(conn, false);
+		}
+
+		DBusMessage *msg, *reply;
+
+		msg = dbus_message_new_method_call("org.pacrunner",
+						   "/org/pacrunner/client",
+						   "org.pacrunner.Client",
+						   "FindProxyForURL");
+		if (!msg)
+			throw runtime_error("Unable to create PacRunner DBus call");
+
+		string dest_str = dest.to_string();
+		string dest_host = dest.get_host();
+		const char *dest_cstr = dest_str.c_str();
+		const char *dest_host_cstr = dest_host.c_str();
+
+		dbus_message_append_args(msg, DBUS_TYPE_STRING, &dest_cstr,
+					 DBUS_TYPE_STRING, &dest_host_cstr,
+					 DBUS_TYPE_INVALID);
+
+		reply = dbus_connection_send_with_reply_and_block(conn, msg, -1, NULL);
+
+		dbus_message_unref(msg);
+
+		if (!reply)
+			throw runtime_error("Failed to get DBus response from PacRunner");
+
+		scoped_dbus_message smsg(reply);
+		char *str = NULL;
+		dbus_message_get_args(reply, NULL, DBUS_TYPE_STRING, &str, DBUS_TYPE_INVALID);
+
+		if (!str || !strlen(str) || !::strcmp(str, "DIRECT"))
+			response.push_back(url("direct://"));
+		else if (!strncmp(str, "PROXY ", 6))
+			response.push_back(url("http://" + string(str + 6)));
+		else if (!strncmp(str, "SOCKS ", 6))
+			response.push_back(url("socks://" + string(str + 6)));
+		else {
+			throw runtime_error("Unrecognised proxy response from PacRunner: " + string(str));
+		}
+		return response;
+	}
+
+private:
+	DBusConnection *conn;
+};
+
+MM_MODULE_INIT_EZ(pacrunner_config_extension, true, NULL, NULL);

--- a/libproxy/modules/config_pacrunner.cpp
+++ b/libproxy/modules/config_pacrunner.cpp
@@ -103,12 +103,16 @@ public:
 		char *str = NULL;
 		dbus_message_get_args(reply, NULL, DBUS_TYPE_STRING, &str, DBUS_TYPE_INVALID);
 
-		if (!str || !strlen(str) || !::strcmp(str, "DIRECT"))
+		if (!str || !strlen(str) || !strcasecmp(str, "DIRECT"))
 			response.push_back(url("direct://"));
-		else if (!strncmp(str, "PROXY ", 6))
+		else if (!strncasecmp(str, "PROXY ", 6))
 			response.push_back(url("http://" + string(str + 6)));
-		else if (!strncmp(str, "SOCKS ", 6))
+		else if (!strncasecmp(str, "SOCKS ", 6))
 			response.push_back(url("socks://" + string(str + 6)));
+		else if (!strncasecmp(str, "SOCKS4 ", 7))
+			response.push_back(url("socks4://" + string(str + 7)));
+		else if (!strncasecmp(str, "SOCKS5 ", 7))
+			response.push_back(url("socks5://" + string(str + 7)));
 		else {
 			throw runtime_error("Unrecognised proxy response from PacRunner: " + string(str));
 		}


### PR DESCRIPTION
This is a new submission of the closed PR https://github.com/libproxy/libproxy/pull/35. Reading the discussion there, I've added a real `test()` function which tests whether the `org.pacrunner` name is owned on D-Bus (iow, whether pacrunner has already been started by some other entity). This test does not have the side effect to start pacrunner.

Note that NetworkManager has now functionality to update pacrunner's configuration when proxy settings are available for a NM connection (either via DHCP or similar, or by explicit configuration options). AFAICS, NetworkManager **starts** the pacrunner D-Bus service only when it's itself starting up. During connection activation, NM does not start the service.

Therefore, on "normal" Linux distributions, the test I implemented would only activate the pacrunner module if both NM and pacrunner are installed, and if NM is in use for connection management.

