### PR TITLE
RFC: Keep visibility of non-px_* symbols

### DIFF
--- a/libproxy/libproxy.map
+++ b/libproxy/libproxy.map
@@ -4,6 +4,4 @@ LIBPROXY_0.4.16 {
     px_proxy_factory_get_proxies;
     px_proxy_factory_free_proxies;
     px_proxy_factory_free;
-  local: *;
 };
-


### PR DESCRIPTION
Symbols other than px_* are still used by modules, so they have to be visible
as well. Unfortunately the version script can't deal with C++ classes properly,
it's not possible to match the vtable, typeinfo, etc. without resorting to the
platform specific mangling.

As a workaround, keep the default visibility of symbols which aren't explicitly
mentioned, this means that while users of private API wouldn't be caught
anymore, everything continues to work as usual, just with px_* being versioned.

This is an RFC as I'm not sure what happens to not explicitly mentioned symbols.
Maybe someone has an idea how this can be solved in a better way.