### PR TITLE
Remove dynamic exception specifications

### DIFF
--- a/libproxy/extension_config.hpp
+++ b/libproxy/extension_config.hpp
@@ -31,7 +31,7 @@ using namespace libmodman;
 class DLL_PUBLIC config_extension : public extension<config_extension> {
 public:
 	// Abstract methods
-	virtual vector<url>      get_config(const url &dst) throw (runtime_error)=0;
+	virtual vector<url>      get_config(const url &dst) =0;
 
 	// Virtual methods
 	virtual string   get_ignore(const url &dst);

--- a/libproxy/extension_pacrunner.cpp
+++ b/libproxy/extension_pacrunner.cpp
@@ -30,7 +30,7 @@ pacrunner_extension::~pacrunner_extension() {
 	if (this->pr) delete this->pr;
 }
 
-pacrunner* pacrunner_extension::get(const string &pac, const url& pacurl) throw (bad_alloc) {
+pacrunner* pacrunner_extension::get(const string &pac, const url& pacurl) {
 	if (this->pr) {
 		if (this->last == pac)
 			return this->pr;

--- a/libproxy/extension_pacrunner.hpp
+++ b/libproxy/extension_pacrunner.hpp
@@ -26,7 +26,7 @@
 #define PX_PACRUNNER_MODULE_EZ(name, symb, smod) \
 	class name ## _pacrunner_extension : public pacrunner_extension { \
 	protected: \
-		virtual pacrunner* create(string pac, const url& pacurl) throw (bad_alloc) { \
+		virtual pacrunner* create(string pac, const url& pacurl) { \
 			return new name ## _pacrunner(pac, pacurl); \
 		} \
 	}; \
@@ -41,13 +41,13 @@ class DLL_PUBLIC pacrunner {
 public:
 	pacrunner(const string &pac, const url& pacurl);
 	virtual ~pacrunner() {};
-	virtual string run(const url& url) throw (bad_alloc)=0;
+	virtual string run(const url& url) =0;
 };
 
 class DLL_PUBLIC pacrunner_extension : public extension<pacrunner_extension, true> {
 public:
 	// Virtual methods
-	virtual pacrunner* get(const string &pac, const url& pacurl) throw (bad_alloc);
+	virtual pacrunner* get(const string &pac, const url& pacurl);
 	virtual ~pacrunner_extension();
 
 	// Final methods
@@ -55,7 +55,7 @@ public:
 
 protected:
 	// Abstract methods
-	virtual pacrunner* create(string pac, const url& pacurl) throw (bad_alloc)=0;
+	virtual pacrunner* create(string pac, const url& pacurl) =0;
 
 private:
 	pacrunner* pr;

--- a/libproxy/modules/config_envvar.cpp
+++ b/libproxy/modules/config_envvar.cpp
@@ -24,7 +24,7 @@ using namespace libproxy;
 
 class envvar_config_extension : public config_extension {
 public:
-	vector<url> get_config(const url &dst) throw (runtime_error) {
+	vector<url> get_config(const url &dst) {
 		const char *proxy = NULL;
                 vector<url> response;
 

--- a/libproxy/modules/config_gnome.cpp
+++ b/libproxy/modules/config_gnome.cpp
@@ -189,7 +189,7 @@ public:
 		kill(this->pid, SIGTERM);
 	}
 
-	vector<url> get_config(const url &dest) throw (runtime_error) {
+	vector<url> get_config(const url &dest) {
 		// Check for changes in the config
 		fd_set rfds;
 		struct timeval timeout = { 0, 0 };

--- a/libproxy/modules/config_gnome3.cpp
+++ b/libproxy/modules/config_gnome3.cpp
@@ -183,7 +183,7 @@ public:
 		}
 	}
 
-	vector<url> get_config(const url &dest) throw (runtime_error) {
+	vector<url> get_config(const url &dest) {
 		// Check for changes in the config
 		fd_set rfds;
 		struct timeval timeout = { 0, 0 };

--- a/libproxy/modules/config_kde.cpp
+++ b/libproxy/modules/config_kde.cpp
@@ -66,7 +66,7 @@ public:
         command = "";
     }
 
-    vector<url> get_config(const url &dst) throw (runtime_error) {
+    vector<url> get_config(const url &dst) {
         // See constructor
         if(command.empty())
             throw runtime_error("Unable to read configuration");
@@ -134,7 +134,7 @@ public:
 	}
 
 private:
-    string command_output(const string &cmdline) throw (runtime_error) {
+    string command_output(const string &cmdline) {
         // Capture stderr as well
         const string command = "(" + cmdline + ")2>&1";
         FILE *pipe = popen(command.c_str(), "r");
@@ -158,7 +158,7 @@ private:
     }
 
     // Neither key nor def must contain '
-    const string &kde_config_val(const string &key, const string &def) throw (runtime_error) {
+    const string &kde_config_val(const string &key, const string &def) {
         if (cache_needs_refresh())
             cache.clear();
         else {

--- a/libproxy/modules/config_macosx.cpp
+++ b/libproxy/modules/config_macosx.cpp
@@ -114,7 +114,7 @@ static string capitalize(string str) {
 
 class macosx_config_extension : public config_extension {
 public:
-	vector<url> get_config(const url &the_url) throw (runtime_error) {
+	vector<url> get_config(const url &the_url) {
 		string tmp;
 		CFDictionaryRef proxies = SCDynamicStoreCopyProxies(NULL);
 		vector<url> response;

--- a/libproxy/modules/config_pacrunner.cpp
+++ b/libproxy/modules/config_pacrunner.cpp
@@ -48,7 +48,7 @@ public:
 		DBusMessage *msg;
 	};
 
-	vector<url> get_config(const url &dest) throw (runtime_error) {
+	vector<url> get_config(const url &dest) {
 		// Make sure we have a valid connection with a proper match
 		DBusConnection *conn = this->conn;
 		vector<url> response;

--- a/libproxy/modules/config_sysconfig.cpp
+++ b/libproxy/modules/config_sysconfig.cpp
@@ -124,7 +124,7 @@ public:
 	~sysconfig_config_extension() {
 	}
    
-	vector<url> get_config(const url &dst) throw (runtime_error) {
+	vector<url> get_config(const url &dst) {
 		map<string,string>::const_iterator it = _data.find("PROXY_ENABLED");
 		vector<url> response;
 

--- a/libproxy/modules/config_w32reg.cpp
+++ b/libproxy/modules/config_w32reg.cpp
@@ -108,7 +108,7 @@ static map<string, string> parse_manual(string data) {
 
 class w32reg_config_extension : public config_extension {
 public:
-	vector<url> get_config(const url &dst) throw (runtime_error) {
+	vector<url> get_config(const url &dst) {
 		char        *tmp = NULL;
 		uint32_t enabled = 0;
 		vector<url> response;

--- a/libproxy/modules/pacrunner_mozjs.cpp
+++ b/libproxy/modules/pacrunner_mozjs.cpp
@@ -113,7 +113,7 @@ static JSClass cls = {
 
 class mozjs_pacrunner : public pacrunner {
 public:
-	mozjs_pacrunner(const string &pac, const url& pacurl) throw (bad_alloc) : pacrunner(pac, pacurl) {
+	mozjs_pacrunner(const string &pac, const url& pacurl) : pacrunner(pac, pacurl) {
 
 		// Set defaults
 		this->jsctx = nullptr;
@@ -173,7 +173,7 @@ public:
 		JS_ShutDown();
 	}
 
-	string run(const url& url_) throw (bad_alloc) {
+	string run(const url& url_) {
 		// Build arguments to the FindProxyForURL() function
 		string tmpurl(url_.to_string());
 		string tmphost(url_.get_host());

--- a/libproxy/modules/pacrunner_natus.cpp
+++ b/libproxy/modules/pacrunner_natus.cpp
@@ -66,7 +66,7 @@ static Value myIpAddress(Value& ths, Value& fnc, vector<Value>& arg) {
 
 class natus_pacrunner : public pacrunner {
 public:
-	natus_pacrunner(string pac, const url& pacurl) throw (bad_alloc) : pacrunner(pac, pacurl) {
+	natus_pacrunner(string pac, const url& pacurl) : pacrunner(pac, pacurl) {
 		Value exc;
 
 		// Create the basic context
@@ -93,7 +93,7 @@ public:
 		throw bad_alloc();
 	}
 
-	string run(const url& url_) throw (bad_alloc) {
+	string run(const url& url_) {
 		vector<Value> args;
 		args.push_back(glb.newString(url_.to_string()));
 		args.push_back(glb.newString(url_.get_host()));

--- a/libproxy/modules/pacrunner_webkit.cpp
+++ b/libproxy/modules/pacrunner_webkit.cpp
@@ -38,7 +38,7 @@ using namespace libproxy;
 #define INET6_ADDRSTRLEN 46
 #endif
 
-static char *jstr2str(JSStringRef str, bool release) throw (bad_alloc)
+static char *jstr2str(JSStringRef str, bool release)
 {
 	char *tmp = new char[JSStringGetMaximumUTF8CStringSize(str)+1];
 	JSStringGetUTF8CString(str, tmp, JSStringGetMaximumUTF8CStringSize(str)+1);
@@ -103,7 +103,7 @@ public:
 		JSGlobalContextRelease(this->jsctx);
 	}
 
-	webkit_pacrunner(string pac, const url& pacurl) throw (bad_alloc) : pacrunner(pac, pacurl) {
+	webkit_pacrunner(string pac, const url& pacurl) : pacrunner(pac, pacurl) {
 		JSStringRef str  = NULL;
 		JSObjectRef func = NULL;
 
@@ -144,7 +144,7 @@ public:
 		throw bad_alloc();
 	}
 
-	string run(const url& url_) throw (bad_alloc) {
+	string run(const url& url_) {
 		JSStringRef str = NULL;
 		JSValueRef  val = NULL;
 		string      tmp;

--- a/libproxy/url.cpp
+++ b/libproxy/url.cpp
@@ -117,7 +117,7 @@ string url::encode(const string &data, const string &valid_reserved) {
 	return encoded.str();
 }
 
-url::url(const string &url) throw(parse_error)
+url::url(const string &url)
 	: m_orig(url), m_port(0), m_ips(NULL) {
 	size_t idx = 0;
 	size_t hier_part_start, hier_part_end;
@@ -300,7 +300,7 @@ url& url::operator=(const url& url) {
 	return *this;
 }
 
-url& url::operator=(const string &strurl) throw (parse_error) {
+url& url::operator=(const string &strurl) {
 	url tmp(strurl);
 	*this = tmp;
 	return *this;

--- a/libproxy/url.hpp
+++ b/libproxy/url.hpp
@@ -50,10 +50,10 @@ public:
 
 	~url();
 	url(const url& url);
-	url(const string& url) throw (parse_error);
+	url(const string& url);
 	bool operator==(const url& url) const;
 	url& operator=(const url& url);
-	url& operator=(const string &url) throw (parse_error);
+	url& operator=(const string &url);
 
 	string   get_host()     const;
 	sockaddr const* const* get_ips(bool usedns);


### PR DESCRIPTION
C++98 called and it wants its dynamic exception specifications back!
We'd better comply.

https://en.cppreference.com/w/cpp/language/except_spec

Fixes #127