### PR TITLE
Stop defining _BSD_SOURCE

### DIFF
--- a/utils/proxy.c
+++ b/utils/proxy.c
@@ -16,7 +16,6 @@
  * License along with this library; if not, write to the Free Software
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  ******************************************************************************/
-#define _BSD_SOURCE
 
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
It's not needed here and has been deprecated for a long time. Fixes:

[ 82%] Building CXX object libproxy/CMakeFiles/config_kde.dir/modules/config_kde.cpp.o
In file included from /usr/include/bits/libc-header-start.h:33,
                 from /usr/include/stdio.h:27,
                 from /home/mcatanzaro/Projects/libproxy/utils/proxy.c:21:
/usr/include/features.h:187:3: warning: #warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE" [-Wcpp]
  187 | # warning "_BSD_SOURCE and _SVID_SOURCE are deprecated, use _DEFAULT_SOURCE"
      |   ^~~~~~~