### PR TITLE
Parse the windows bypass list

### DIFF
--- a/libproxy/modules/config_w32reg.cpp
+++ b/libproxy/modules/config_w32reg.cpp
@@ -16,6 +16,7 @@
  * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301 USA
  ******************************************************************************/
 
+#include <algorithm>
 #include "../extension_config.hpp"
 using namespace libproxy;
 
@@ -160,7 +161,10 @@ public:
 		if (get_registry(W32REG_BASEKEY, "ProxyOverride", &tmp, NULL, NULL)) {
 			string po = tmp;
 			delete tmp;
-			if (po == "<local>")
+			const char windowsDelimiter = ';';
+			const char libproxyDelimiter = ',';
+			replace(po.begin(), po.end(), windowsDelimiter, libproxyDelimiter );
+			if (po.length()>0)
 				return po;
 		}
 		return "";


### PR DESCRIPTION
Converts the windows registry bypass list from semi-colon delimited to comma delimited
Returns the full comma-delimited list of bypass urls.

This should address an open issue https://github.com/libproxy/libproxy/issues/96