### PR TITLE
Never use system libmodman

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,24 +33,9 @@ include(cmake/paths.cmk)
 option(WITH_WEBKIT3 "Build against gtk-3 version of webkitgtk" OFF)
 
 ### Subdirectories
-# Conditionally build bundled libmodman
-option(FORCE_SYSTEM_LIBMODMAN "Force using system libmodman" OFF)
-find_package(libmodman QUIET)
-if(LIBMODMAN_FOUND)
-    if("${LIBMODMAN_VERSION_MAJOR}" STREQUAL "2")
-      message(STATUS "Building with system libmodman")    
-    else()
-      message(FATAL_ERROR "Found incompatible libmodman on your system (libmodman 2.X is needed)")
-    endif()
-else()
-    if(FORCE_SYSTEM_LIBMODMAN)
-      message(FATAL_ERROR "Libmodman could not be found on your system")
-    else()
-      message(STATUS "Building with bundled libmodman")
-      add_subdirectory(libmodman)
-      include_directories(${CMAKE_CURRENT_SOURCE_DIR})
-    endif()
-endif()
+
+add_subdirectory(libmodman)
+include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 
 # Conditionally build bindings
 if(NOT WIN32)


### PR DESCRIPTION
I was very surprised to discover that libmodman is a system library.
It's packaged separately from libproxy in distros (I checked Fedora and
openSUSE), and libproxy's build system does not install its files, but
libproxy nonetheless appears to be the only upstream. Distros build the
system library from a decade-old tarball.

Anyway, nothing besides libproxy uses it, so the system package should
probably be retired. By using our own internal libmodman, we can make
API and ABI changes to modernize libmodman and improve its safety,
without having to worry about other consumers (which don't exist,
anyway).