### PR TITLE
Release: 0.4.16

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -8,6 +8,10 @@ New in version 0.4.16:
 * Small performance improvements
 * pxgsettings: use the correct syntax to connect to the changed signal (silences annoying output on console)
 * Support python3 up to version 3.9
+* Fix buffer overflow when PAC is enabled (CVE-2020-26154)
+* Rewrite url::recvline to be nonrecursive (CVE-2020-25219)
+* Remove nonfunctional and crashy pacrunner caching
+* Never use system libmodman (no other consumers, not maintained)
 
 New in Version 0.4.15:
 ==============================

--- a/libproxy/CMakeLists.txt
+++ b/libproxy/CMakeLists.txt
@@ -1,6 +1,6 @@
 ### Project info
 project(libproxy)
-set_project_version(0 4 15)
+set_project_version(0 4 16)
 
 ### Add a global compilation stuff
 if (WIN32)


### PR DESCRIPTION
Let's prepare a 0.4.16 release; enough stuff accumulated to justify this release finally

Then we should work on 0.5, which should revive the dbusify branch