### PR TITLE
python bindings: fix "TypeError: _argtypes_ must be a sequence of types"

### DIFF
--- a/bindings/python/libproxy.py
+++ b/bindings/python/libproxy.py
@@ -44,9 +44,9 @@ else:
 # Load libproxy
 _libproxy = _load("proxy", 1)
 _libproxy.px_proxy_factory_new.restype = ctypes.POINTER(ctypes.c_void_p)
-_libproxy.px_proxy_factory_free.argtypes = ctypes.c_void_p,
+_libproxy.px_proxy_factory_free.argtypes = [ctypes.c_void_p]
 _libproxy.px_proxy_factory_get_proxies.restype = ctypes.POINTER(ctypes.c_void_p)
-_libproxy.px_proxy_factory_free_proxies.argtypes = ctypes.POINTER(ctypes.c_void_p)
+_libproxy.px_proxy_factory_free_proxies.argtypes = [ctypes.POINTER(ctypes.c_void_p)]
 
 class ProxyFactory(object):
     """A ProxyFactory object is used to provide potential proxies to use
@@ -141,7 +141,7 @@ class ProxyFactory(object):
                 proxies.append(proxy_bytes.decode('utf-8', errors='replace'))
             i += 1
 
-        _libproxy.px_proxy_factory_free_proxies(proxies)
+        _libproxy.px_proxy_factory_free_proxies(array)
         
         return proxies
         


### PR DESCRIPTION
Fixes #125