### PR TITLE
python: Do not load the libc anymore

### DIFF
--- a/bindings/python/libproxy.py
+++ b/bindings/python/libproxy.py
@@ -35,12 +35,6 @@ def _load(name, *versions):
         return ctypes.cdll.LoadLibrary(name_ver)
     raise ImportError("Unable to find %s library" % name)
 
-# Load C library
-if platform.system() == "Windows":
-    _libc = ctypes.cdll.msvcrt
-else:
-    _libc = _load("c", 6)
-
 # Load libproxy
 _libproxy = _load("proxy", 1)
 _libproxy.px_proxy_factory_new.restype = ctypes.POINTER(ctypes.c_void_p)


### PR DESCRIPTION
This is not needed since the addition of px_proxy_factory_free_proxies()
in d52cc34458b1d6a524df12db2671fa3a15892fcf