### PR TITLE
python: Support Python 3.10 and above

### DIFF
--- a/bindings/python/python2/CMakeLists.txt
+++ b/bindings/python/python2/CMakeLists.txt
@@ -6,7 +6,7 @@ if(PYTHON2INTERP_FOUND)
   if(NOT PYTHON2_SITEPKG_DIR)
     execute_process(COMMAND
 		    ${PYTHON2_EXECUTABLE}
-		    -c "import sys; print (sys.version[0:3])"
+		    -c "import sys; print('{}.{}'.format(*sys.version_info[0:2]))"
 		    OUTPUT_VARIABLE PYTHON2_VERSION
 		    OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/bindings/python/python3/CMakeLists.txt
+++ b/bindings/python/python3/CMakeLists.txt
@@ -6,7 +6,7 @@ if(PYTHON3INTERP_FOUND)
   if(NOT PYTHON3_SITEPKG_DIR)
     execute_process(COMMAND
 		    ${PYTHON3_EXECUTABLE}
-		    -c "import sys; print (sys.version[0:3])"
+		    -c "import sys; print('{}.{}'.format(*sys.version_info[0:2]))"
 		    OUTPUT_VARIABLE PYTHON3_VERSION
 		    OUTPUT_STRIP_TRAILING_WHITESPACE)
 

--- a/cmake/FindPython3Interp.cmake
+++ b/cmake/FindPython3Interp.cmake
@@ -39,7 +39,7 @@
 
 unset(_Python3_NAMES)
 
-set(_Python3_VERSIONS 3.9 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
+set(_Python3_VERSIONS 3.10 3.9 3.8 3.7 3.6 3.5 3.4 3.3 3.2 3.1 3.0)
 
 if(Python3Interp_FIND_VERSION)
     if(Python3Interp_FIND_VERSION_COUNT GREATER 1)


### PR DESCRIPTION
As suggested by Miro Hrončok, change the way that the Python interpreter
version is found. Additionally, update the static list of accepted
Python 3 versions.

https://bugzilla.redhat.com/show_bug.cgi?id=1898060

I am guessing that it would be simpler to use the newer FindPython3 functionality in CMake 3.12 and above, but I do not know much about CMake, sorry!