### PR TITLE
Add host port to request header

### DIFF
--- a/libproxy/url.cpp
+++ b/libproxy/url.cpp
@@ -457,7 +457,7 @@ char* url::get_pac() {
 
 	// Build the request string
 	request  = "GET " + (m_path.size() > 0 ? m_path : "/") + m_query + " HTTP/1.1\r\n";
-	request += "Host: " + m_host + "\r\n";
+	request += "Host: " + m_host + (m_port != 80 ? ":" + std::to_string(m_port) : "") + "\r\n";
 	request += "Accept: " + string(PAC_MIME_TYPE) + "\r\n";
 	request += "Connection: close\r\n";
 	request += "\r\n";


### PR DESCRIPTION
The request header in get_pac() currently misses the host port and thus breaks
every proxy running on another port. See https://gitlab.gnome.org/GNOME/glib-networking/-/issues/138 for example.

Add this missing port in case it is not http default port 80.