### PR TITLE
config_kde: Use kf5-config instead of qtpaths

### DIFF
--- a/libproxy/modules/config_kde.cpp
+++ b/libproxy/modules/config_kde.cpp
@@ -46,7 +46,7 @@ public:
             command_output("kreadconfig5 --key nonexistant");
 
             try {
-                parse_dir_list(command_output("qtpaths --paths GenericConfigLocation"));
+                parse_dir_list(command_output("kf5-config --path config"));
             }
             catch(...) {}
 


### PR DESCRIPTION
`qtpaths` is a developer tool which is not guaranteed to exist on all KDE installations (notably KDE neon).  If it doesn't exist, the cache isn't used at all.

The equivalent to `kde4-config` is `kf5-config`, let's use that.

See also https://bugs.kde.org/show_bug.cgi?id=445813#c2

I think the proper way would be to make this module use D-Bus instead of calling `kreadconfig5` over and over again. But this is a quick fix without which the whole caching stuff is useless for the average user.