### PR TITLE
Add gnome-wayland to permitted DESKTOP_SESSION

### DIFF
--- a/libproxy/modules/config_gnome3.cpp
+++ b/libproxy/modules/config_gnome3.cpp
@@ -299,6 +299,8 @@ static bool gnome_config_extension_test() {
 			|| (getenv("DESKTOP_SESSION")
 				&& string(getenv("DESKTOP_SESSION")) == "gnome")
 			|| (getenv("DESKTOP_SESSION")
+				&& string(getenv("DESKTOP_SESSION")) == "gnome-wayland")
+			|| (getenv("DESKTOP_SESSION")
 				&& string(getenv("DESKTOP_SESSION")) == "mate"));
 }
 


### PR DESCRIPTION
Only GNOME3 is affected since support for Wayland begins at 3.2.0.