### PR TITLE
Fix perl testing and enable it by default

### DIFF
--- a/bindings/perl/lib/CMakeLists.txt
+++ b/bindings/perl/lib/CMakeLists.txt
@@ -1,2 +1,2 @@
-add_custom_target(PMlibproxy ALL ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/Libproxy.pm ${CMAKE_BINARY_DIR}/perl/blib/lib/Libproxy.pm)
+add_custom_target(PMlibproxy ALL ${CMAKE_COMMAND} -E copy ${CMAKE_CURRENT_SOURCE_DIR}/Libproxy.pm ${CMAKE_BINARY_DIR}/perl/Net/Libproxy.pm)
 install( FILES Libproxy.pm DESTINATION ${PX_PERL_ARCH}/Net )

--- a/bindings/perl/src/CMakeLists.txt
+++ b/bindings/perl/src/CMakeLists.txt
@@ -9,7 +9,7 @@ add_custom_command(OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/Libproxy.c
 
 set(Libproxy_LIB_SRCS Libproxy.c)
 
-set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/perl/blib/arch/auto/Net)
+set(LIBRARY_OUTPUT_PATH ${CMAKE_BINARY_DIR}/perl/auto/Net/Libproxy)
 add_library(PLlibproxy SHARED ${Libproxy_LIB_SRCS})
 
 set(PLlibproxy_LIB_DEPENDENCIES libproxy pthread)

--- a/bindings/perl/t/CMakeLists.txt
+++ b/bindings/perl/t/CMakeLists.txt
@@ -1,1 +1,2 @@
-add_custom_target(test prove -b ${CMAKE_CURRENT_SOURCE_DIR})
+add_test(NAME perl COMMAND prove -b ${CMAKE_CURRENT_SOURCE_DIR})
+set_property(TEST perl APPEND PROPERTY ENVIRONMENT "PERL5LIB=${CMAKE_BINARY_DIR}/perl")


### PR DESCRIPTION
The module files for testing were installed in the wrong location and blib
wasn't even enabled. Fix the location and use plain PERL5LIB.

Hook it up to ctest by using add_test instead of a custom target, which even
conflicted with ctest's own target.

Fixes #171

Not sure whether this is correct, but at least it works here.