### PR TITLE
bindings: perl: Use ccflags from %Config for libproxy module compilation

### DIFF
--- a/bindings/perl/CMakeLists.txt
+++ b/bindings/perl/CMakeLists.txt
@@ -33,6 +33,13 @@ if(PERL_FOUND AND PERLLIBS_FOUND)
         OUTPUT_VARIABLE PX_PERL_ARCH)
       set (PX_PERL_LIB ${PERL_SITELIB})
     endif()
+
+    # PERL_EXTRA_C_FLAGS is not complete, we need full flags (including e.g.
+    # _FILE_OFFSET_BITS=64) for compatibility.
+    EXECUTE_PROCESS(COMMAND ${PERL_EXECUTABLE} -MConfig -e "print \$Config{ccflags}"
+      OUTPUT_VARIABLE PX_PERL_CCFLAGS)
+    # Convert it to a "list" suitable for target_compile_options.
+    string(REPLACE " " ";" PX_PERL_CCFLAGS ${PX_PERL_CCFLAGS})
   endif()
 
   add_subdirectory(lib)

--- a/bindings/perl/src/CMakeLists.txt
+++ b/bindings/perl/src/CMakeLists.txt
@@ -18,6 +18,7 @@ if(PERL_LINK_LIBPERL)
 endif()
 
 target_link_libraries(PLlibproxy ${PLlibproxy_LIB_DEPENDENCIES})
+target_compile_options(PLlibproxy PRIVATE ${PX_PERL_CCFLAGS})
 set_target_properties(PLlibproxy PROPERTIES OUTPUT_NAME "Libproxy")
 set_target_properties(PLlibproxy PROPERTIES PREFIX "")
 


### PR DESCRIPTION
This is needed to achieve (binary and source) compatibility. Unfortunately
there doesn't appear to be a more official way, even PERL_EXTRA_C_FLAGS is not
complete.

Fixes #182