### PR TITLE
add alert function to pacrunners

### DIFF
--- a/src/backend/plugins/pacrunner-duktape/pacrunner-duktape.c
+++ b/src/backend/plugins/pacrunner-duktape/pacrunner-duktape.c
@@ -104,12 +104,19 @@ my_ip_address (duk_context *ctx)
 }
 
 static duk_ret_t
-alert (duk_context *ctx) {
-  if(getenv ("_PX_DEBUG_PACALERT") == NULL)
+alert (duk_context *ctx)
+{
+  const char *str = NULL;
+
+  /* do nothing if PX_DEBUG_PACALERT environment is not set */
+  if (!getenv ("PX_DEBUG_PACALERT"))
     return 0;
-  const char *str = duk_get_string (ctx, 0);
+
+  /* only get first argument of alert() as string */
+  str = duk_get_string (ctx, 0);
   if (!str)
     return 0;
+
   fprintf (stderr, "PAC-alert: %s\n", str);
   return 0;
 }

--- a/src/backend/plugins/pacrunner-duktape/pacrunner-duktape.c
+++ b/src/backend/plugins/pacrunner-duktape/pacrunner-duktape.c
@@ -103,6 +103,17 @@ my_ip_address (duk_context *ctx)
   return duk_error (ctx, DUK_ERR_ERROR, "Unable to find hostname!");
 }
 
+static duk_ret_t
+alert (duk_context *ctx) {
+  if(getenv ("_PX_DEBUG_PACALERT") == NULL)
+    return 0;
+  const char *str = duk_get_string (ctx, 0);
+  if (!str)
+    return 0;
+  fprintf (stderr, "PAC-alert: %s\n", str);
+  return 0;
+}
+
 static void
 px_pacrunner_duktape_init (PxPacRunnerDuktape *self)
 {
@@ -115,6 +126,9 @@ px_pacrunner_duktape_init (PxPacRunnerDuktape *self)
 
   duk_push_c_function (self->ctx, my_ip_address, 1);
   duk_put_global_string (self->ctx, "myIpAddress");
+
+  duk_push_c_function (self->ctx, alert, 1);
+  duk_put_global_string (self->ctx, "alert");
 
   duk_push_string (self->ctx, JAVASCRIPT_ROUTINES);
   if (duk_peval_noresult (self->ctx))


### PR DESCRIPTION
This PR add the (widely used?) `alert` function to each pacrunner, which directly print to stderr, prefixed with `PAC-alert:`.

Update:
Unless the `_PX_DEBUG_PACALERT` environment is set, this `alert` function will do nothing (since there is no 'browser console'), which just create the function name in pacrunner context to avoid ReferenceError while interpreting pac script.