### PR TITLE
Fix static build missing deps

### DIFF
--- a/libmodman/CMakeLists.txt
+++ b/libmodman/CMakeLists.txt
@@ -7,7 +7,7 @@ else(WIN32)
 endif(WIN32)
 include_directories(${CMAKE_SOURCE_DIR})
 
-add_library(modman STATIC
+add_library(modman OBJECT
             module.hpp
             module_manager.hpp
             module_manager.cpp)


### PR DESCRIPTION
When build libproxy as static library. It didn't install libmodman. This cause unresolved symbols.
See https://github.com/microsoft/vcpkg/issues/28417