### PR TITLE
Improve GNOME/KDE get_config() execution

### DIFF
--- a/src/backend/plugins/config-gnome/config-gnome.c
+++ b/src/backend/plugins/config-gnome/config-gnome.c
@@ -177,10 +177,13 @@ px_config_gnome_get_config (PxConfig     *config,
   if (!self->available)
     return;
 
+  mode = g_settings_get_enum (self->proxy_settings, "mode");
+  if (mode == GNOME_PROXY_MODE_NONE)
+    return;
+
   if (px_manager_is_ignore (uri, g_settings_get_strv (self->proxy_settings, "ignore-hosts")))
     return;
 
-  mode = g_settings_get_enum (self->proxy_settings, "mode");
   if (mode == GNOME_PROXY_MODE_AUTO) {
     char *autoconfig_url = g_settings_get_string (self->proxy_settings, "autoconfig-url");
 

--- a/src/backend/plugins/config-kde/config-kde.c
+++ b/src/backend/plugins/config-kde/config-kde.c
@@ -251,17 +251,19 @@ px_config_kde_get_config (PxConfig     *config,
                           GStrvBuilder *builder)
 {
   PxConfigKde *self = PX_CONFIG_KDE (config);
-  const char *scheme = g_uri_get_scheme (uri);
+  const char *scheme;
   g_autofree char *proxy = NULL;
 
   if (!self->available)
     return;
 
-  if (!self->proxy_type)
+  if (self->proxy_type == KDE_PROXY_TYPE_NONE)
     return;
 
   if (px_manager_is_ignore (uri, self->no_proxy))
     return;
+
+  scheme = g_uri_get_scheme (uri);
 
   switch (self->proxy_type) {
     case KDE_PROXY_TYPE_MANUAL:


### PR DESCRIPTION
Only check for ignore hosts if proxy are in use.