### PR TITLE
Move glib2 inclusion out of c++ protection.

### DIFF
--- a/src/libproxy/proxy.h
+++ b/src/libproxy/proxy.h
@@ -22,11 +22,11 @@
 
 #pragma once
 
+#include <gio/gio.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#include <gio/gio.h>
 
 /**
  * SECTION:px-proxy


### PR DESCRIPTION
Fixes usage of header file from C++.

Addresses one part of #226.