### PR TITLE
Use glib-object header instead of gio

### DIFF
--- a/src/libproxy/proxy.h
+++ b/src/libproxy/proxy.h
@@ -22,7 +22,7 @@
 
 #pragma once
 
-#include <gio/gio.h>
+#include <glib-object.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
3rd party libraries (like QT) which defines same variable names will clash if we use gio/gio.h in public proxy.h. Switch to minimal required to fix compilation issues with QT5/6.

Fixes: https://github.com/libproxy/libproxy/issues/226