### PR TITLE
Link with libsocket where needed (#234)

### DIFF
--- a/src/backend/plugins/pacrunner-duktape/meson.build
+++ b/src/backend/plugins/pacrunner-duktape/meson.build
@@ -4,6 +4,7 @@ if get_option(plugin_name)
 
 duktape_dep = dependency('duktape')
 m_dep = cc.find_library('m', required : false)
+socket_dep = cc.find_library('socket', required: false)
 
 px_backend_sources += [
   'plugins/@0@/@0@.c'.format(plugin_name),
@@ -11,7 +12,8 @@ px_backend_sources += [
 
 px_backend_deps += [
   duktape_dep,
-  m_dep
+  m_dep,
+  socket_dep
 ]
 
 endif


### PR DESCRIPTION
Some systems need extra dependencies, such as libsocket, for networking functions.

Fixes: https://github.com/libproxy/libproxy/issues/234