### PR TITLE
Update gobject dependency in pkgconfig file

### DIFF
--- a/src/libproxy/meson.build
+++ b/src/libproxy/meson.build
@@ -49,7 +49,8 @@ pkg.generate(
   name: 'libproxy',
   filebase: package_api_name,
   description: 'libproxy',
-  requires: 'gio-2.0',
+  # Needed due to #include <glib-object.h> in proxy.h
+  requires_private: 'gobject-2.0',
   install_dir: join_paths(get_option('libdir'), 'pkgconfig')
 )
 


### PR DESCRIPTION
Since 4a4f54ca754689fb5a47dc7361e2530344ce82f5, proxy.h includes glib-gobject.h instead of gio/gio.h. We should reflect that change in the pkgconfig file.

Also, we can move the dependency from Requires to Requires.private since we only need the cflags; consumers do not need to link against libgobject.