### PR TITLE
Specify library version more completely

### DIFF
--- a/src/libproxy/meson.build
+++ b/src/libproxy/meson.build
@@ -29,6 +29,7 @@ libproxy = shared_library(
   link_args : vflag,
   link_depends : mapfile,
   soversion: '1',
+  version: meson.project_version(),
   install: true,
   install_rpath: pkglibdir,
 )


### PR DESCRIPTION
If the library version is not specified, meson installs the shared object using only the soversion, and this causes ldconfig to emit a warning that the shared object is not a symlink. Specifying a version that matches the project version means that version is used for the shared object, and the soversion-named file is then a symilnk to that, which is common across other libraries, and avoids the warning from ldconfig.

https://bugzilla.redhat.com/show_bug.cgi?id=2247508