### PR TITLE
Use the correct separator character for Windows ProxyOverride

### DIFF
--- a/src/backend/plugins/config-windows/config-windows.c
+++ b/src/backend/plugins/config-windows/config-windows.c
@@ -192,7 +192,7 @@ px_config_windows_get_config (PxConfig     *self,
   guint32 enabled = 0;
 
   if (get_registry (W32REG_BASEKEY, "ProxyOverride", &tmp, NULL, NULL)) {
-    g_auto (GStrv) no_proxy = g_strsplit (tmp, ",", -1);
+    g_auto (GStrv) no_proxy = g_strsplit (tmp, ";", -1);
 
     if (px_manager_is_ignore (uri, no_proxy))
       return;


### PR DESCRIPTION
The ProxyOverride entries are separated by semicolons, not by commas

<img width="526" alt="proxy-config-uri" src="https://github.com/libproxy/libproxy/assets/126883023/3ae400a5-ba99-40bc-8d59-463fe3a9e9f2">
<img width="736" alt="proxy-config-registry" src="https://github.com/libproxy/libproxy/assets/126883023/f704d91a-966c-45fd-a70a-93a046df7f5f">
