### PR TITLE
Add curl option to the generated config for backend instead

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -110,11 +110,6 @@ curl_dep = dependency('libcurl', required: get_option('curl'))
 ws2_32_dep = cc.find_library('ws2_32', required : with_platform_windows)
 gsettings_desktop_schema = dependency('gsettings-desktop-schemas', required: get_option('config-gnome'))
 
-config_h = configuration_data()
-config_h.set_quoted('PACKAGE_VERSION', meson.project_version())
-config_h.set('HAVE_CURL', get_option('curl'))
-configure_file(output: 'config.h', configuration: config_h)
-
 subdir('src')
 subdir('tests')
 subdir('docs')

--- a/src/backend/meson.build
+++ b/src/backend/meson.build
@@ -6,6 +6,7 @@ backend_config_h.set('HAVE_CONFIG_OSX', get_option('config-osx') and with_platfo
 backend_config_h.set('HAVE_CONFIG_SYSCONFIG', get_option('config-sysconfig'))
 backend_config_h.set('HAVE_CONFIG_WINDOWS', get_option('config-windows') and with_platform_windows)
 backend_config_h.set('HAVE_PACRUNNER_DUKTAPE', get_option('pacrunner-duktape'))
+backend_config_h.set('HAVE_CURL', get_option('curl'))
 configure_file(output: 'px-backend-config.h', configuration: backend_config_h)
 
 px_backend_sources = [

--- a/src/backend/px-manager.c
+++ b/src/backend/px-manager.c
@@ -19,7 +19,6 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-#include "config.h"
 #include "px-backend-config.h"
 
 #include <glib.h>


### PR DESCRIPTION
It is only used there, and the project root is added to the list of include directories last. This means that a config.h may inadvertedly be included from a completely different place when building libproxy as a subproject. The backend directory, where the generated px-backend-config.h ends up is the first include path in the list.

This commit removes config.h entirely, as the only other thing in it, the generated PACKAGE_VERSION define, is not used anywhere