### PR TITLE
Windows: Detect scheme presence in proxy URLs more robustly

### DIFF
--- a/src/backend/plugins/config-windows/config-windows.c
+++ b/src/backend/plugins/config-windows/config-windows.c
@@ -143,9 +143,8 @@ get_registry (const char  *key,
 static char *
 build_proxy_uri (const char *uri)
 {
-  g_autofree char *scheme = g_uri_parse_scheme (uri);
   char *proxy_server = NULL;
-  if (!scheme) {
+  if (!g_strstr_len (uri, -1, "://")) {
     proxy_server = g_strdup_printf ("http://%s", uri);
   } else {
     proxy_server = g_strdup (uri);


### PR DESCRIPTION
Windows proxy servers can be set either with or without a scheme where without implies http, and with or without a port where without implies the default port for the scheme.

Unfortunately, g_uri_parse_scheme("proxy.example.com:3128") returns "proxy.example.com" rather than NULL (while
g_uri_parse_scheme("1.2.3.4:3128") returns NULL), meaning that such proxy configurations did not get http:// prepended to them, causing e.g. GProxy to reject them.

With this change we simply search for the presence of :// in the URI instead. While a URI technically doesn't have to contain // after the scheme separator, such URIs should not occur in this context