### PR TITLE
Fix refcounting in px_proxy_factory_copy (#280)

### DIFF
--- a/src/libproxy/proxy.c
+++ b/src/libproxy/proxy.c
@@ -48,6 +48,7 @@ px_proxy_factory_new (void)
 pxProxyFactory *
 px_proxy_factory_copy (pxProxyFactory *self)
 {
+  g_object_ref (self->manager);
   return g_memdup2 (self, sizeof (pxProxyFactory));
 }
 

--- a/tests/libproxy-test.c
+++ b/tests/libproxy-test.c
@@ -69,6 +69,7 @@ test_libproxy_dup (Fixture    *self,
   pxProxyFactory *dup = g_boxed_copy (PX_TYPE_PROXY_FACTORY, self->pf);
 
   g_assert_nonnull (dup);
+  px_proxy_factory_free (dup);
 }
 
 static void

--- a/tests/libproxy-test.c
+++ b/tests/libproxy-test.c
@@ -66,7 +66,7 @@ static void
 test_libproxy_dup (Fixture    *self,
                    const void *user_data)
 {
-  pxProxyFactory *dup = g_boxed_copy (PX_TYPE_PROXY_FACTORY, &self->pf);
+  pxProxyFactory *dup = g_boxed_copy (PX_TYPE_PROXY_FACTORY, self->pf);
 
   g_assert_nonnull (dup);
 }


### PR DESCRIPTION
* tests: Copy pxProxyFactory correctly
    
    The second argument to g_boxed_copy() is meant to be a pointer to the
    boxed instance itself, not a pointer to a pointer to the boxed instance.
    For example, `g_boxed_copy (G_TYPE_STRV, environ)` is correct (equivalent
    to g_strdupv() in this case), but `g_boxed_copy (G_TYPE_STRV, &environ)`
    would be incorrect. The same principle applies here.
    
    The test passed despite this because self->pf and
    &self->pf happen to both be pointer-sized, and as a result of
    https://github.com/libproxy/libproxy/issues/280, the data that is pointed
    to was copied byte-by-byte but not otherwise used; but this will no
    longer be true when #280 is fixed, so the test needs fixing first.

* px_proxy_factory_copy: Add a new reference to the manager
    
    Otherwise there is no guarantee that the object will continue to exist
    after the original factory is destroyed, and both the copy and the
    original factory will try to unref it when destroyed, which is a
    programming error.
    
    Resolves: https://github.com/libproxy/libproxy/issues/280

* tests: Don't leak the copied pxProxyFactory
    
    Previously the copy was never freed, which hid the bugs fixed by the
    previous commits.
    
    Reproduces: https://github.com/libproxy/libproxy/issues/280