### PR TITLE
backend: Convert into a static library

### DIFF
--- a/src/backend/meson.build
+++ b/src/backend/meson.build
@@ -33,14 +33,12 @@ px_backend_inc = include_directories('.')
 
 subdir('plugins')
 
-px_backend = shared_library(
+px_backend = static_library(
   'pxbackend-@0@'.format(api_version),
   px_backend_sources,
   dependencies: px_backend_deps,
   c_args: px_backend_c_args,
-  install: true,
-  install_dir: pkglibdir,
-  install_rpath: pkglibdir
+  gnu_symbol_visibility : 'hidden',
 )
 
 px_backend_dep = declare_dependency(

--- a/src/libproxy/meson.build
+++ b/src/libproxy/meson.build
@@ -31,7 +31,6 @@ libproxy = shared_library(
   soversion: '1',
   version: meson.project_version(),
   install: true,
-  install_rpath: pkglibdir,
 )
 
 libproxy_dep = declare_dependency (


### PR DESCRIPTION
Mark all of its symbols as hidden visibility, so that they do not affect the public ABI.

This means the public shared library no longer needs a RPATH/RUNPATH, so drop that.