### PR TITLE
meson: Don't build OSX plugin on iOS

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -98,12 +98,8 @@ endif
 project_link_args = cc.get_supported_link_arguments(warning_link_args)
 add_project_link_arguments (project_link_args, language: 'c')
 
-_platforms = []
 host_system = host_machine.system()
-if host_machine.system() == 'windows'
-    _platforms = ['windows']
-endif
-with_platform_windows = _platforms.contains('windows')
+with_platform_windows = host_system == 'windows'
 with_platform_darwin = ['darwin', 'ios'].contains(host_system)
 
 module_suffix = []

--- a/meson.build
+++ b/meson.build
@@ -100,7 +100,11 @@ add_project_link_arguments (project_link_args, language: 'c')
 
 host_system = host_machine.system()
 with_platform_windows = host_system == 'windows'
-with_platform_darwin = ['darwin', 'ios'].contains(host_system)
+with_platform_darwin = cc.compiles('''#include <Availability.h>
+#include <TargetConditionals.h>
+#if !TARGET_OS_OSX || __MAC_OS_X_VERSION_MIN_REQUIRED <= 100100L
+#error "Not building for macOS"
+#endif''')
 
 module_suffix = []
 # Keep the autotools convention for shared module suffix because GModule


### PR DESCRIPTION
Fails to build with:

`../src/backend/plugins/config-osx/config-osx.c:284:29: error: 'SCDynamicStoreCopyProxies' is unavailable: not available on iOS`

Which is true, it's only available on macOS 10.1+

https://developer.apple.com/documentation/systemconfiguration/1517088-scdynamicstorecopyproxies
