### PR TITLE
Expose missing functions in symbol map

### DIFF
--- a/src/libproxy/libproxy.map
+++ b/src/libproxy/libproxy.map
@@ -1,3 +1,9 @@
+LIBPROXY_0.5.5 {
+  global:
+    px_proxy_factory_get_type;
+    px_proxy_factory_copy;
+};
+
 LIBPROXY_0.4.16 {
   global:
     px_proxy_factory_new;


### PR DESCRIPTION
px_proxy_factory_get_type and px_proxy_factory_copy should be in symbol map. Add it.

Fixes: https://github.com/libproxy/libproxy/issues/281