### PR TITLE
symver: Fix symbol map to be a valid tree

### DIFF
--- a/src/libproxy/libproxy.map
+++ b/src/libproxy/libproxy.map
@@ -1,9 +1,3 @@
-LIBPROXY_0.5.5 {
-  global:
-    px_proxy_factory_get_type;
-    px_proxy_factory_copy;
-};
-
 LIBPROXY_0.4.16 {
   global:
     px_proxy_factory_new;
@@ -11,4 +5,10 @@ LIBPROXY_0.4.16 {
     px_proxy_factory_free_proxies;
     px_proxy_factory_free;
 };
+
+LIBPROXY_0.5.5 {
+  global:
+    px_proxy_factory_get_type;
+    px_proxy_factory_copy;
+} LIBPROXY_0.4.16;
 


### PR DESCRIPTION
The ordering is not really needed - but it makes reading the file easier (if it ever gets large)