### PR TITLE
Properly handle empty proxy ignore entry

### DIFF
--- a/src/backend/px-manager.c
+++ b/src/backend/px-manager.c
@@ -716,7 +716,7 @@ ignore_domain (GUri *uri,
   if (g_strcmp0 (ignore, "*") == 0)
     return TRUE;
 
-  if (!host || || !ignore || strlen (ignore) == 0)
+  if (!host || !ignore || strlen (ignore) == 0)
     return FALSE;
 
   ignore_split = g_strsplit (ignore, ":", -1);

--- a/src/backend/px-manager.c
+++ b/src/backend/px-manager.c
@@ -716,7 +716,7 @@ ignore_domain (GUri *uri,
   if (g_strcmp0 (ignore, "*") == 0)
     return TRUE;
 
-  if (!host || strlen (ignore) == 0)
+  if (!host || || !ignore || strlen (ignore) == 0)
     return FALSE;
 
   ignore_split = g_strsplit (ignore, ":", -1);

--- a/src/backend/px-manager.c
+++ b/src/backend/px-manager.c
@@ -716,7 +716,7 @@ ignore_domain (GUri *uri,
   if (g_strcmp0 (ignore, "*") == 0)
     return TRUE;
 
-  if (!host || !ignore)
+  if (!host || strlen (ignore) == 0)
     return FALSE;
 
   ignore_split = g_strsplit (ignore, ":", -1);


### PR DESCRIPTION
The crash reported in https://github.com/libproxy/libproxy/issues/299 is not due to `ignore` being NULL, but it being an empty string. This can easily happen, as at least some backends create the list of "ignores" by calling `strsplit` on a delimited string. If there's a stray delimiter character in that string, the resulting vector will contain empty strings.

In `ignore_domain`, `g_strsplit` is then called (to separate port from hostname) on an empty string. `g_strsplit` has a quirk: if called on an empty string, it returns an empty array.

Then `ignore_host` is set to the first entry in that (empty) array, which will make it a NULL pointer.

Then `strlen` is called on `ignore_host`, causing the access violation and a crash.

This crash can be reproduced on Windows with libproxy 0.5.7 by setting the ProxyOverride registry value to `;` (single semicolon). It's likely reproducible with other backends as well (the original report was with Gnome)