### PR TITLE
Remove white space in key value

### DIFF
--- a/src/backend/plugins/config-sysconfig/config-sysconfig.c
+++ b/src/backend/plugins/config-sysconfig/config-sysconfig.c
@@ -114,6 +114,7 @@ px_config_sysconfig_set_config_file (PxConfigSysConfig *self,
       value = g_string_new (kv[1]);
       g_string_replace (value, "\"", "", 0);
       g_string_replace (value, "\r", "", 0);
+      g_string_replace (value, " ", "", 0);
 
       if (strcmp (kv[0], "PROXY_ENABLED") == 0) {
         self->proxy_enabled = g_ascii_strncasecmp (value->str, "yes", 3) == 0;


### PR DESCRIPTION
Some time there are white spaces in key value like key NO_PROXY, if white space is not removed, the host name can't be ignored.