### PR TITLE
Add support for Pantheon

### DIFF
--- a/src/backend/plugins/config-gnome/config-gnome.c
+++ b/src/backend/plugins/config-gnome/config-gnome.c
@@ -70,6 +70,7 @@ px_config_gnome_init (PxConfigGnome *self)
   /* Remember that XDG_CURRENT_DESKTOP is a list of strings. */
   if (strstr (desktops, "GNOME") == NULL &&
       strstr (desktops, "MATE") == NULL &&
+      strstr (desktops, "Pantheon") == NULL &&
       strstr (desktops, "Cinnamon") == NULL)
     return;
 

--- a/tests/config-gnome-test.c
+++ b/tests/config-gnome-test.c
@@ -258,6 +258,29 @@ test_config_gnome_cinnamon (Fixture    *self,
   g_assert_cmpstr (config[0], ==, "wpad://");
 }
 
+static void
+test_config_gnome_pantheon (Fixture    *self,
+                            const void *user_data)
+{
+  g_autoptr (PxManager) manager = NULL;
+  g_autoptr (GError) error = NULL;
+  g_auto (GStrv) config = NULL;
+  g_autoptr (GUri) uri = NULL;
+
+  if (!g_setenv ("XDG_CURRENT_DESKTOP", "Pantheon", TRUE)) {
+    g_warning ("Could not set XDG_CURRENT_DESKTOP environment, abort");
+    return;
+  }
+
+  manager = px_test_manager_new ("config-gnome", NULL);
+  g_settings_set_enum (self->proxy_settings, "mode", GNOME_PROXY_MODE_AUTO);
+  g_settings_set_string (self->proxy_settings, "autoconfig-url", "");
+
+  uri = g_uri_parse ("https://www.example.com", G_URI_FLAGS_NONE, &error);
+  config = px_manager_get_configuration (manager, uri);
+  g_assert_cmpstr (config[0], ==, "wpad://");
+}
+
 int
 main (int    argc,
       char **argv)
@@ -273,6 +296,7 @@ main (int    argc,
   g_test_add ("/config/gnome/fail", Fixture, NULL, fixture_setup, test_config_gnome_fail, fixture_teardown);
   g_test_add ("/config/gnome/mate", Fixture, NULL, fixture_setup, test_config_gnome_mate, fixture_teardown);
   g_test_add ("/config/gnome/cinnamon", Fixture, NULL, fixture_setup, test_config_gnome_cinnamon, fixture_teardown);
+  g_test_add ("/config/gnome/pantheon", Fixture, NULL, fixture_setup, test_config_gnome_pantheon, fixture_teardown);
 
   return g_test_run ();
 }


### PR DESCRIPTION
Extend config-gnome plugin check for Pantheon.

Fixes: https://github.com/libproxy/libproxy/issues/332