### PR TITLE
ci: Add wrap files and a CI job for MSVC

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,7 @@ jobs:
           libcurl4-openssl-dev \
           valac
     - name: Build setup
-      run: meson setup build -Db_coverage=true
+      run: meson setup build -Db_coverage=true --wrap-mode=nodownload
     - name: Build
       run: ninja -C build
     - name: Tests and Coverage
@@ -52,11 +52,29 @@ jobs:
         brew install gobject-introspection duktape gcovr gi-docgen vala gsettings-desktop-schemas
     - name: Build and Test
       run: |
-        meson setup build -Ddocs=false
+        meson setup build -Ddocs=false --wrap-mode=nodownload
         ninja -C build
         ninja -C build test
 
-  build-windows:
+  build-msvc:
+    runs-on: windows-latest
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+    - uses: actions/setup-python@v6
+      with:
+        python-version: '3.9'
+    - name: Setup
+      run: |
+        pip install meson ninja
+    - name: Build and test
+      run: |
+        meson setup --vsenv build -Ddocs=false -Dcurl=false -Dconfig-gnome=false -Dconfig-osx=false -Dconfig-kde=false -Dconfig-xdp=false -Dpacrunner-duktape=false -Dintrospection=false
+        meson compile -C build
+        meson test -C build
+
+  build-msys2:
     runs-on: windows-latest
     continue-on-error: true
     env:
@@ -91,7 +109,7 @@ jobs:
       - name: Build and Test
        # Disable docs for the moment until msys2 gi-docgen update has landed
         run: |
-          meson setup build -Ddocs=false
+          meson setup build -Ddocs=false --wrap-mode=nodownload
           ninja -C build
           ninja -C build test
 

--- a/subprojects/glib.wrap
+++ b/subprojects/glib.wrap
@@ -1,0 +1,11 @@
+[wrap-file]
+directory = glib-2.86.3
+source_url = https://download.gnome.org/sources/glib/2.86/glib-2.86.3.tar.xz
+source_fallback_url = https://wrapdb.mesonbuild.com/v2/glib_2.86.3-1/get_source/glib-2.86.3.tar.xz
+source_filename = glib-2.86.3.tar.xz
+source_hash = b3211d8d34b9df5dca05787ef0ad5d7ca75dec998b970e1aab0001d229977c65
+wrapdb_version = 2.86.3-1
+
+[provide]
+dependency_names = gthread-2.0, gobject-2.0, gmodule-no-export-2.0, gmodule-export-2.0, gmodule-2.0, glib-2.0, gio-2.0, gio-windows-2.0, gio-unix-2.0
+program_names = glib-genmarshal, glib-mkenums, glib-compile-schemas, glib-compile-resources, gio-querymodules, gdbus-codegen

--- a/subprojects/libffi.wrap
+++ b/subprojects/libffi.wrap
@@ -1,0 +1,8 @@
+[wrap-git]
+directory=libffi
+url=https://gitlab.freedesktop.org/gstreamer/meson-ports/libffi.git
+push-url=git@gitlab.freedesktop.org:gstreamer/meson-ports/libffi.git
+revision=meson-3.2.9999.4
+
+[provide]
+libffi = ffi_dep

--- a/subprojects/pcre2.wrap
+++ b/subprojects/pcre2.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = pcre2-10.47
+source_url = https://github.com/PCRE2Project/pcre2/releases/download/pcre2-10.47/pcre2-10.47.tar.bz2
+source_filename = pcre2-10.47.tar.bz2
+source_hash = 47fe8c99461250d42f89e6e8fdaeba9da057855d06eb7fc08d9ca03fd08d7bc7
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/pcre2_10.47-3/pcre2-10.47.tar.bz2
+patch_filename = pcre2_10.47-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/pcre2_10.47-3/get_patch
+patch_hash = 42df135f63e216141ffcc30e3e7c8ae6bdea21f7638828cbab5f7ad484fa9044
+wrapdb_version = 10.47-3
+
+[provide]
+dependency_names = libpcre2-8, libpcre2-16, libpcre2-32, libpcre2-posix

--- a/subprojects/zlib.wrap
+++ b/subprojects/zlib.wrap
@@ -1,0 +1,13 @@
+[wrap-file]
+directory = zlib-1.3.1
+source_url = https://zlib.net/fossils/zlib-1.3.1.tar.gz
+source_fallback_url = https://github.com/mesonbuild/wrapdb/releases/download/zlib_1.3.1-3/zlib-1.3.1.tar.gz
+source_filename = zlib-1.3.1.tar.gz
+source_hash = 9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23
+patch_filename = zlib_1.3.1-3_patch.zip
+patch_url = https://wrapdb.mesonbuild.com/v2/zlib_1.3.1-3/get_patch
+patch_hash = fe43804f04c4dedc11fe6b5e1790666989cf9983f4e20ae0fad3fe88a428abad
+wrapdb_version = 1.3.1-3
+
+[provide]
+dependency_names = zlib


### PR DESCRIPTION
Demonstrates the build failure with MSVC.

Replaces https://github.com/libproxy/libproxy/pull/353

Relates to https://github.com/libproxy/libproxy/issues/347

We probably want to move the boolean options to feature options so that these options can be auto-disabled on Windows :slightly_smiling_face: 