### PR TITLE
Support TLS-encrypted web proxies

### DIFF
--- a/src/backend/px-manager.c
+++ b/src/backend/px-manager.c
@@ -506,6 +506,8 @@ px_manager_run_pac (PxPacRunner  *pacrunner,
 
       if (g_ascii_strncasecmp (method, "proxy", 5) == 0) {
         proxy_string = g_uri_to_string (proxy_uri);
+      } else if (g_ascii_strncasecmp (method, "https", 5) == 0) {
+        proxy_string = g_strconcat ("https://", server, NULL);
       } else if (g_ascii_strncasecmp (method, "socks4a", 7) == 0) {
         proxy_string = g_strconcat ("socks4a://", server, NULL);
       } else if (g_ascii_strncasecmp (method, "socks4", 6) == 0) {


### PR DESCRIPTION
This is an obscure feature that is nonetheless supported by web browsers and curl.  It is the equivalent of wrapping the proxy connection in stunnel.

https://www.chromium.org/developers/design-documents/secure-web-proxy/
https://chromium.googlesource.com/chromium/src/+/66d3bd76/net/docs/proxy.md#HTTPS-proxy-scheme
https://curl.se/docs/manpage.html#--proxy

This is [used](https://bitbucket.org/anticensority/antizapret-pac-generator-light/src/83830eb2888b00e631171155efe4ba409e924993/generate-pac.sh?at=master#lines-220) in the wild to thwart DPI-based internet censorship.