### PR TITLE
manager: don't fall back to direct on PAC errors

### DIFF
--- a/src/backend/plugins/pacrunner-duktape/pacrunner-duktape.c
+++ b/src/backend/plugins/pacrunner-duktape/pacrunner-duktape.c
@@ -176,10 +176,13 @@ px_pacrunner_duktape_set_pac (PxPacRunner *pacrunner,
 
   duk_push_lstring (self->ctx, content, len);
 
-  if (duk_peval_noresult (self->ctx)) {
+  if (duk_peval (self->ctx)) {
+    g_debug ("%s: Duktape failed to evaluate PAC: %s", G_STRFUNC, duk_safe_to_string (self->ctx, -1));
+    duk_pop (self->ctx);
     return FALSE;
   }
 
+  duk_pop (self->ctx);
   return TRUE;
 }
 

--- a/src/backend/px-manager.c
+++ b/src/backend/px-manager.c
@@ -646,6 +646,7 @@ px_manager_get_proxies_sync (PxManager  *self,
   g_autoptr (GUri) uri = NULL;
   g_auto (GStrv) config = NULL;
   g_autoptr (GError) error = NULL;
+  gboolean pac_error = FALSE;
 
   g_mutex_lock (&self->mutex);
 
@@ -678,6 +679,8 @@ px_manager_get_proxies_sync (PxManager  *self,
 
         px_manager_run_pac (pacrunner, self->pac_data, uri, builder);
       }
+    } else if (g_str_has_prefix (g_uri_get_scheme (conf_url), "pac+")) {
+      pac_error = TRUE;
     } else if (!g_str_has_prefix (g_uri_get_scheme (conf_url), "wpad") && !g_str_has_prefix (g_uri_get_scheme (conf_url), "pac+")) {
       g_autofree char *conf_url_string = g_uri_to_string (conf_url);
 
@@ -685,7 +688,15 @@ px_manager_get_proxies_sync (PxManager  *self,
     }
   }
 
-  /* In case no proxy could be found, assume direct connection */
+  /* An explicitly configured PAC that cannot be loaded or evaluated is an
+   * unrecoverable configuration error. Do not silently bypass it with the
+   * implicit direct fallback. */
+  if (((GPtrArray *)builder)->len == 0 && pac_error) {
+    g_mutex_unlock (&self->mutex);
+    return NULL;
+  }
+
+  /* In case no proxy could be found, assume direct connection. */
   if (((GPtrArray *)builder)->len == 0)
     px_strv_builder_add_proxy (builder, "direct://");
 

--- a/tests/data/px-manager-invalid-pac
+++ b/tests/data/px-manager-invalid-pac
@@ -1,0 +1,5 @@
+PROXY_ENABLED="yes"
+HTTP_PROXY="pac+http://127.0.0.1:1983/px-manager-invalid.pac"
+HTTPS_PROXY="pac+http://127.0.0.1:1983/px-manager-invalid.pac"
+FTP_PROXY="pac+http://127.0.0.1:1983/px-manager-invalid.pac"
+NO_PROXY="localhost, 127.0.0.1"

--- a/tests/data/px-manager-invalid.pac
+++ b/tests/data/px-manager-invalid.pac
@@ -1,0 +1,2 @@
+function FindProxyForURL(url, host) {
+  return "PROXY 127.0.0.1:1984";

--- a/tests/px-manager-test.c
+++ b/tests/px-manager-test.c
@@ -288,6 +288,32 @@ test_get_proxies_pac (Fixture    *self,
   g_main_loop_run (self->loop);
 }
 
+static gpointer
+get_proxies_invalid_pac (gpointer data)
+{
+  Fixture *self = data;
+  g_auto (GStrv) config = NULL;
+
+  g_test_expect_message ("pxbackend", G_LOG_LEVEL_WARNING, "*Unable to set PAC*");
+  config = px_manager_get_proxies_sync (self->manager, "https://www.example.com");
+  g_test_assert_expected_messages ();
+  g_assert_null (config);
+
+  g_main_loop_quit (self->loop);
+
+  return NULL;
+}
+
+static void
+test_get_proxies_invalid_pac (Fixture    *self,
+                              const void *user_data)
+{
+  g_autoptr (GThread) thread = NULL;
+
+  thread = g_thread_new ("test", (GThreadFunc)get_proxies_invalid_pac, self);
+  g_main_loop_run (self->loop);
+}
+
 static void
 test_get_proxies_pac_debug (Fixture    *self,
                             const void *user_data)
@@ -432,6 +458,7 @@ main (int    argc,
   g_test_add ("/pac/get_proxies_direct", Fixture, "px-manager-direct", fixture_setup, test_get_proxies_direct, fixture_teardown);
   g_test_add ("/pac/get_proxies_nonpac", Fixture, "px-manager-nonpac", fixture_setup, test_get_proxies_nonpac, fixture_teardown);
   g_test_add ("/pac/get_proxies_pac", Fixture, "px-manager-pac", fixture_setup, test_get_proxies_pac, fixture_teardown);
+  g_test_add ("/pac/get_proxies_invalid_pac", Fixture, "px-manager-invalid-pac", fixture_setup, test_get_proxies_invalid_pac, fixture_teardown);
   g_test_add ("/pac/wpad", Fixture, "px-manager-wpad", fixture_setup, test_get_wpad, fixture_teardown);
   g_test_add ("/pac/get_proxies_pac_debug", Fixture, "px-manager-pac", fixture_setup, test_get_proxies_pac_debug, fixture_teardown);
 


### PR DESCRIPTION
## Summary

Do not silently fall back to an implicit direct connection when an explicitly configured `pac+...` PAC cannot be downloaded or evaluated.

`px_manager_get_proxies_sync()` currently treats a failed explicit PAC expansion like an empty proxy result. Its final generic fallback then returns `direct://`, which can bypass the routing policy the caller explicitly configured.

The public proxy factory API already documents `NULL` for unrecoverable errors. This change tracks explicit PAC failure and returns `NULL` only when no other configured proxy produced a result. Normal offline/no-proxy/WPAD availability fallbacks continue to use the existing direct behavior.

The Duktape runner also preserves the evaluation error long enough to log the actual syntax/runtime diagnostic at debug level before cleaning its stack.

## Reproduction

This adds a deterministic regression using a locally served, syntactically truncated PAC.

On current `main` (`872cc5f4b13acef2298c3c5d5d8166fc24d9c3d4`):

- the PAC downloads successfully
- Duktape rejects it
- the manager warning is emitted
- the proxy result becomes `direct://`
- the regression fails because the result is non-NULL

With this change:

- Duktape reports the parse error at debug level
- the existing manager warning remains
- the proxy result is `NULL`
- the regression passes

This independently reproduces the behavior described in #365 without depending on that issue's ES2015 PAC example.

## Compatibility / tests

- New `/pac/get_proxies_invalid_pac` regression passes.
- Existing PX Manager tests pass, including valid PAC proxy results, PAC `DIRECT`, SOCKS variants, WPAD, and ordinary direct fallback behavior.
- Config sysconfig test passes.
- Libproxy tests pass 3/3. On the Windows-backed D: test build, Meson could not create its `libproxy.so.1` SONAME symlink; running the exact built library through an equivalent symlink on the WSL filesystem made those tests pass.
- Project sources compile under the existing warning-heavy Meson configuration.
- `git diff --check` is clean.

## Security context

This is fail-closed hardening for applications that rely on an explicitly configured PAC as a proxy-routing policy boundary. It does not claim that all libproxy users treat proxying as a security boundary, or that PAC failure itself grants code execution.

Issue #365 already documents the fail-open symptom; this PR is the patch for that public issue rather than a first-discovery claim.
